### PR TITLE
Gh pages theme: change table overflow to scroll for mobile

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.inner {
+  max-width: 100%;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -5,4 +5,5 @@
 
 .inner {
   max-width: 100%;
+  overflow: scroll;
 }


### PR DESCRIPTION
Page width to 100%
Table overflow scrolls now (via parent div)